### PR TITLE
fix(questions): preserve user-selected category and bypass NLP auto-t…

### DIFF
--- a/api/controllers/questionController.js
+++ b/api/controllers/questionController.js
@@ -94,17 +94,8 @@ const postQuestion = asyncHandler(async (req, res) => {
       }
       console.log("user found", um);
       const message = "Question posted successfully";
-      //defining tag for the question
-      const query = body.body;
-      let classified_tag = "General"; // Default tag
-
-      try {
-        const nlpBaseUrl = process.env.NLP_SERVICE_URL || "http://127.0.0.1:5001";
-        const tag_response = await axios.post(`${nlpBaseUrl}/tag`, { query });
-        classified_tag = tag_response.data;
-      } catch (nlpError) {
-        console.error("NLP Tagging Service Error:", nlpError.message);
-      }
+      // Use the tag provided by the student, or default to General
+      let classified_tag = body.tag || "General";
 
       //creating question
       await questionModel


### PR DESCRIPTION
## Overview
This PR resolves a categorization bug during question submission where the student-selected category was being entirely ignored by the backend.

## Changes Made
- Bypassed the forced request to the `NLP_SERVICE_URL` in the `postQuestion` controller.
- The backend now strictly extracts and preserves the `body.tag` string sent from the frontend's `FormData`, defaulting to "General" only if no category is provided.

## Impact
Questions posted from the student dashboard will now reliably display the exact category (e.g., "Admission", "Hostel") the user clicked on, rather than an overridden automated tag.
